### PR TITLE
[Parser] IPC key값들을 위한 파일 이름에 pid를 추가했습니다.

### DIFF
--- a/include/trace_replay.h
+++ b/include/trace_replay.h
@@ -143,6 +143,7 @@ struct io_job {
         char *buf;
 };
 
+#define BASE_KEY_PATHNAME_LEN 33
 #define MSGQ_KEY_PATHNAME "/tmp/trace_replay_msgq"
 #define SHM_KEY_PATHNAME "/tmp/trace_replay_shm"
 #define SEM_KEY_PATHNAME "/tmp/trace_replay_sem"

--- a/trace-replay/trace_replay.c
+++ b/trace-replay/trace_replay.c
@@ -59,6 +59,7 @@ struct timeval tv_start, tv_end, tv_result, tv_start2;
 double execution_time = 0.0;
 double timeout;
 long long wanted_io_count;
+char key_pathname[BASE_KEY_PATHNAME_LEN];
 
 void sgenrand(unsigned long seed);
 unsigned long genrand();
@@ -877,7 +878,8 @@ int print_result(int nr_trace, int nr_thread, FILE *fp, int detail)
                 if (total_bytes < total_stat.total_bytes)
                         total_bytes = total_stat.total_bytes;
 
-                server_qkey = ftok(MSGQ_KEY_PATHNAME, PROJECT_ID);
+                sprintf(key_pathname, "%s_%d", MSGQ_KEY_PATHNAME, getpid());
+                server_qkey = ftok(key_pathname, PROJECT_ID);
                 if (server_qkey < 0) {
                         perror("ftok: server_qkey");
                         goto no_msg;
@@ -989,7 +991,8 @@ void finalize()
 
         fclose(log_fp);
 
-        while ((server_qkey = ftok(MSGQ_KEY_PATHNAME, PROJECT_ID)) < 0)
+        sprintf(key_pathname, "%s_%d", MSGQ_KEY_PATHNAME, getpid());
+        while ((server_qkey = ftok(key_pathname, PROJECT_ID)) < 0)
                 perror("ftok: server_qkey");
 
         while ((server_qid = msgget(server_qkey, 0)) < 0)
@@ -1001,7 +1004,8 @@ void finalize()
         while (msgsnd(server_qid, &rmsg, sizeof(struct realtime_log), 0) < 0)
                 perror("msgsnd");
 
-        server_semkey = ftok(SEM_KEY_PATHNAME, PROJECT_ID);
+        sprintf(key_pathname, "%s_%d", SEM_KEY_PATHNAME, getpid());
+        server_semkey = ftok(key_pathname, PROJECT_ID);
         if (server_semkey < 0) {
                 perror("ftok: server_semkey");
                 goto no_shm;
@@ -1012,7 +1016,8 @@ void finalize()
                 goto no_shm;
         }
 
-        server_shmkey = ftok(SHM_KEY_PATHNAME, PROJECT_ID);
+        sprintf(key_pathname, "%s_%d", SHM_KEY_PATHNAME, getpid());
+        server_shmkey = ftok(key_pathname, PROJECT_ID);
         if (server_shmkey < 0) {
                 perror("ftok: server_shmkey");
                 goto no_shm;


### PR DESCRIPTION
ipc key 값 파일 예시는 다음과 같습니다.

 메세지 큐 key 값 파일: /tmp/trace_replay_msgq_30581
 세마포어 key 값 파일: /tmp/trace_replay_shm_30581
 공유메모리 key 값 파일: /tmp/trace_replay_sem_30581