### PR TITLE
[ALL] Fix the miss typo of the parameter in docker-shm.c

### DIFF
--- a/runner/driver/docker-driver/docker-shm.c
+++ b/runner/driver/docker-driver/docker-shm.c
@@ -40,7 +40,7 @@
 /**
  * @brief Initialize the Semaphore.
  *
- * @param[in] pid Process' ID of using this Semaphore.
+ * @param[in] info `docker_info` structure which wants to init.
  *
  * @return SemaphoreID for success to init, negative value for fail to init.
  */
@@ -106,7 +106,7 @@ exception:
 /**
  * @brief Initialize the Shared Memory.
  *
- * @param[in] pid Process' ID of using this Shared Memory.
+ * @param[in] info `docker_info` structure which wants to init.
  *
  * @return Shared MemoryID for success to init, negative value for fail to init.
  */


### PR DESCRIPTION
Modified that the value of the parameter from `pid` to `info` in the comments.