### PR TITLE
[ALL] Add the `LINKFLAGS` to `SConstruct` file. 

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -19,6 +19,7 @@ env['CC']=["gcc"]
 if env["DEBUG"] == True:
 	env.Append(CFLAGS=["-g", "-pg"])
 	env.Append(CFLAGS=["-DLOG_INFO", "-DDEBUG"])
+	env.Append(LINKFLAGS=["-g", "-pg"])
 	env["PROGRAM_LOCATION"] = "#build/debug"
 else:
 	pass


### PR DESCRIPTION
To generate a `gmon.out` from the executable file, I added the `LINKFLAGS =
"-g -pg"` option to `SConstruct` file.