### PR TITLE
[Runner] Fix the `tr-driver` and enhance the `docker-driver`.

### DIFF
--- a/include/runner.h
+++ b/include/runner.h
@@ -35,8 +35,8 @@
 #define INTERVAL_RESULT_STRING_SIZE (PAGE_SIZE) /**< Expected 4KB */
 #define TOTAL_RESULT_STRING_SIZE (PAGE_SIZE * PAGE_SIZE) /**< Expected 16MB */
 
-#define CGROUP_MIN_WEIGHT 1
-#define CGROUP_MAX_WEIGHT 1000
+#define BFQ_MIN_WEIGHT 1
+#define BFQ_MAX_WEIGHT 1000
 
 enum { RUNNER_FREE_ALL_MASK =
                0xFFFF, /**< This mask checks the flag want to deallocate all. */
@@ -66,5 +66,17 @@ void runner_put_result_string(char *buffer);
 void runner_free(void);
 void runner_config_free(struct runner_config *config, const int flags);
 const struct runner_config *runner_get_global_config(void);
+
+/**
+ * @brief Check the validation of BFQ scheduler's weight.
+ *
+ * @param[in] weight BFQ scheduler's weight.
+ *
+ * @return 1 for valid BFQ weight, 0 for invalid BFQ weight.
+ */
+static inline int runner_is_valid_bfq_weight(unsigned int weight)
+{
+        return (weight <= BFQ_MAX_WEIGHT && weight >= BFQ_MIN_WEIGHT);
+}
 
 #endif

--- a/runner/driver/docker-driver/docker-driver.c
+++ b/runner/driver/docker-driver/docker-driver.c
@@ -253,9 +253,8 @@ static int docker_set_cgroup_state(struct docker_info *current)
         if (ret == 0) { /* Set the weight when BFQ scheduler. */
                 char cmd[PATH_MAX];
 
-                if (current->weight > CGROUP_MAX_WEIGHT ||
-                    current->weight < CGROUP_MIN_WEIGHT) {
-                        pr_info(ERROR, "Weight out of range: \"%d\"\n",
+                if (!runner_is_valid_bfq_weight(current->weight)) {
+                        pr_info(ERROR, "BFQ weight is out of range: \"%u\"\n",
                                 current->weight);
                         return -EINVAL;
                 }

--- a/runner/driver/tr-driver/tr-driver.c
+++ b/runner/driver/tr-driver/tr-driver.c
@@ -257,6 +257,11 @@ static int tr_set_cgroup_state(struct tr_info *current)
 
         ret = strcmp(current->scheduler, tr_valid_scheduler[TR_BFQ_SCHEDULER]);
         if (ret == 0) { /* Set the weight when BFQ scheduler. */
+                if (!runner_is_valid_bfq_weight(current->weight)) {
+                        pr_info(ERROR, "BFQ weight is out of range: \"%u\"\n",
+                                current->weight);
+                        return -EINVAL;
+                }
                 snprintf(cmd, PATH_MAX,
                          "echo %d > /sys/fs/cgroup/blkio/%s%d/blkio.%s.weight",
                          current->weight, current->prefix_cgroup_name,
@@ -333,7 +338,7 @@ static int tr_do_exec(struct tr_info *current)
         tr_print_info(&info);
 #endif
         if (-1 == lstat(info.trace_replay_path, &lstat_info)) {
-                pr_info(ERROR, "trace replay doesn't exist: \"%s\"",
+                pr_info(ERROR, "trace replay doesn't exist: \"%s\"\n",
                         info.trace_replay_path);
                 return -EACCES;
         }

--- a/runner/test/docker-driver-test.c
+++ b/runner/test/docker-driver-test.c
@@ -67,7 +67,7 @@ static const unsigned long key_len = sizeof(key) / sizeof(char *);
 #define NR_TASKS (key_len)
 #define NR_THREAD ((int)(Q_DEPTH / NR_TASKS))
 
-#define FLAGS_MASK (0x3F)
+#define FLAGS_MASK ((0x1 << NR_TASKS) - 1)
 
 static char *json, *task_options;
 static struct json_object *jobject;
@@ -169,8 +169,8 @@ void test(void)
                 for (unsigned long i = 0; i < key_len; i++) {
                         struct json_object *object, *tmp;
                         int type;
-                        if (flags & (0x1 << i)) {
-                                continue;
+                        if (flags == FLAGS_MASK) {
+                                break;
                         }
 
                         buffer = runner_get_interval_result(key[i]);

--- a/runner/test/tr-driver-test.c
+++ b/runner/test/tr-driver-test.c
@@ -67,7 +67,7 @@ static const unsigned long key_len = sizeof(key) / sizeof(char *);
 #define NR_TASKS (key_len)
 #define NR_THREAD ((int)(Q_DEPTH / NR_TASKS))
 
-#define FLAGS_MASK (0x3F) /**< 0b0011 1111 */
+#define FLAGS_MASK ((0x1 << NR_TASKS) - 1)
 
 static char *json, *task_options;
 static struct json_object *jobject;


### PR DESCRIPTION
1. Fixed the implicit error of the `tr-driver` which is described in PR #59 .
2. Added the `runner_is_valid_bfq_weight()` that check inputted the weight is valid in BFQ scheduler.
3. Made unit-test program's `FLAGS_MASK` constant more flexible.