### PR TITLE
[Runner] Refactor the docker-driver and tr-driver, runner.

### DIFF
--- a/include/driver/docker-driver.h
+++ b/include/driver/docker-driver.h
@@ -19,7 +19,7 @@
  * @file docker-driver.h
  * @brief driver declaration part of run `docker with trace-replay`
  * @author SuhoSon (ngeol564@gmail.com)
- * @version 0.1
+ * @version 0.1.1
  * @date 2020-08-19
  */
 #ifndef _DOCKER_DRIVER_H
@@ -167,6 +167,7 @@ struct docker_info {
 int docker_init(void *object);
 int docker_runner(void);
 int docker_valid_scheduler_test(const char *scheduler);
+int docker_has_weight_scheduler(const int scheduler_index);
 int docker_get_interval(const char *key, char *buffer);
 int docker_get_total(const char *key, char *buffer);
 void docker_free(void);

--- a/include/driver/tr-driver.h
+++ b/include/driver/tr-driver.h
@@ -19,7 +19,7 @@
  * @file tr-driver.h
  * @brief driver declaration part of run `trace-replay`
  * @author BlaCkinkGJ (ss5kijun@gmail.com)
- * @version 0.1
+ * @version 0.1.1
  * @date 2020-08-05
  */
 #ifndef _TR_DRIVER_H

--- a/include/driver/tr-driver.h
+++ b/include/driver/tr-driver.h
@@ -164,6 +164,7 @@ struct tr_info {
 int tr_init(void *object);
 int tr_runner(void);
 int tr_valid_scheduler_test(const char *scheduler);
+int tr_has_weight_scheduler(const int scheduler_index);
 int tr_get_interval(const char *key, char *buffer);
 int tr_get_total(const char *key, char *buffer);
 void tr_free(void);

--- a/runner/driver/docker-driver/docker-info.c
+++ b/runner/driver/docker-driver/docker-info.c
@@ -19,7 +19,7 @@
  * @file docker-info.c
  * @brief Initialize the info structure.
  * @author SuhoSon (ngeol564@gmail.com)
- * @version 0.1
+ * @version 0.1.1
  * @date 2020-08-19
  */
 
@@ -130,6 +130,7 @@ static int __docker_info_init(struct json_object *setting, int index,
         struct json_object *tmp;
         struct stat lstat_info;
         int ret = 0;
+        int print_flag = DOCKER_PRINT_NONE;
 
         ENTRY item; /**< Variable for `hsearch`. */
         ENTRY *result;
@@ -182,9 +183,13 @@ static int __docker_info_init(struct json_object *setting, int index,
                 goto exception;
         }
 
+        if (docker_has_weight_scheduler(ret)) {
+                print_flag = DOCKER_ERROR_PRINT;
+        }
+
         ret = docker_info_int_value_set(tmp, "weight", &info->weight,
-                                        DOCKER_ERROR_PRINT);
-        if (0 != ret) {
+                                        print_flag);
+        if (DOCKER_ERROR_PRINT == print_flag && 0 != ret) {
                 goto exception;
         }
 

--- a/runner/driver/tr-driver/tr-driver.c
+++ b/runner/driver/tr-driver/tr-driver.c
@@ -60,6 +60,8 @@ static const char *tr_valid_scheduler[] = {
         NULL,
 };
 
+static const int tr_weight_support_scheduler[] = { TR_BFQ_SCHEDULER };
+
 static struct tr_info *global_info_head = NULL; /**< global `tr_info` list */
 
 /**
@@ -148,6 +150,25 @@ int tr_valid_scheduler_test(const char *scheduler)
                 index++;
         }
         return -EINVAL;
+}
+
+/**
+ * @brief Check the parameter's `scheduler_index` supports weight.
+ *
+ * @param scheduler_index The scheduler's index which is based on `tr_valid_scheduler` and wants to check.
+ *
+ * @return 0 for doesn't support the weight, 1 for supporting the weight
+ */
+int tr_has_weight_scheduler(const int scheduler_index)
+{
+        const int nr_index = sizeof(tr_weight_support_scheduler) / sizeof(int);
+        int index = 0;
+        for (index = 0; index < nr_index; index++) {
+                if (scheduler_index == tr_weight_support_scheduler[index]) {
+                        return 1;
+                }
+        }
+        return 0;
 }
 
 /**
@@ -255,8 +276,14 @@ static int tr_set_cgroup_state(struct tr_info *current)
                 return -EINVAL;
         }
 
-        ret = strcmp(current->scheduler, tr_valid_scheduler[TR_BFQ_SCHEDULER]);
-        if (ret == 0) { /* Set the weight when BFQ scheduler. */
+        ret = tr_valid_scheduler_test(current->scheduler);
+        if (ret) {
+                pr_info(ERROR, " Cannot support the scheduler: \"%s\"\n",
+                        current->scheduler);
+                return ret;
+        }
+        ret = tr_has_weight_scheduler(ret);
+        if (ret) { /* Set the weight when BFQ scheduler. */
                 if (!runner_is_valid_bfq_weight(current->weight)) {
                         pr_info(ERROR, "BFQ weight is out of range: \"%u\"\n",
                                 current->weight);

--- a/runner/driver/tr-driver/tr-driver.c
+++ b/runner/driver/tr-driver/tr-driver.c
@@ -19,7 +19,7 @@
  * @file tr-driver.c
  * @brief Implementation of run the `trace-replay` benchmark.
  * @author BlaCkinkGJ (ss5kijun@gmail.com)
- * @version 0.1
+ * @version 0.1.1
  * @date 2020-08-05
  */
 
@@ -155,7 +155,7 @@ int tr_valid_scheduler_test(const char *scheduler)
 /**
  * @brief Check the parameter's `scheduler_index` supports weight.
  *
- * @param scheduler_index The scheduler's index which is based on `tr_valid_scheduler` and wants to check.
+ * @param[in] scheduler_index The scheduler's index which is based on `tr_valid_scheduler` and wants to check.
  *
  * @return 0 for doesn't support the weight, 1 for supporting the weight
  */

--- a/runner/driver/tr-driver/tr-info.c
+++ b/runner/driver/tr-driver/tr-info.c
@@ -19,7 +19,7 @@
  * @file tr-info.c
  * @brief Initialize the info structure.
  * @author BlaCkinkGJ (ss5kijun@gmail.com)
- * @version 0.1
+ * @version 0.1.1
  * @date 2020-08-10
  */
 

--- a/runner/driver/tr-driver/tr-info.c
+++ b/runner/driver/tr-driver/tr-info.c
@@ -172,19 +172,12 @@ static int __tr_info_init(struct json_object *setting, int index,
                 return ret;
         }
 
-        ret = tr_valid_scheduler_test(info->scheduler);
-        if (ret) {
-                pr_info(ERROR, " Cannot support the scheduler: \"%s\"\n",
-                        info->scheduler);
-                return ret;
-        }
-
         if (tr_has_weight_scheduler(ret)) {
                 print_flag = TR_ERROR_PRINT;
         }
 
         ret = tr_info_int_value_set(tmp, "weight", &info->weight, print_flag);
-        if (print_flag == TR_ERROR_PRINT && 0 != ret) {
+        if (TR_ERROR_PRINT == print_flag && 0 != ret) {
                 return ret;
         }
 

--- a/runner/driver/tr-driver/tr-info.c
+++ b/runner/driver/tr-driver/tr-info.c
@@ -127,6 +127,7 @@ static int __tr_info_init(struct json_object *setting, int index,
         struct json_object *tmp;
         struct stat lstat_info;
         int ret = 0;
+        int print_flag = TR_PRINT_NONE;
 
         ENTRY item; /**< Variable for `hsearch`. */
         ENTRY *result;
@@ -171,9 +172,19 @@ static int __tr_info_init(struct json_object *setting, int index,
                 return ret;
         }
 
-        ret = tr_info_int_value_set(tmp, "weight", &info->weight,
-                                    TR_ERROR_PRINT);
-        if (0 != ret) {
+        ret = tr_valid_scheduler_test(info->scheduler);
+        if (ret) {
+                pr_info(ERROR, " Cannot support the scheduler: \"%s\"\n",
+                        info->scheduler);
+                return ret;
+        }
+
+        if (tr_has_weight_scheduler(ret)) {
+                print_flag = TR_ERROR_PRINT;
+        }
+
+        ret = tr_info_int_value_set(tmp, "weight", &info->weight, print_flag);
+        if (print_flag == TR_ERROR_PRINT && 0 != ret) {
                 return ret;
         }
 

--- a/runner/runner.c
+++ b/runner/runner.c
@@ -49,7 +49,7 @@ static struct runner_config *global_config =
 void runner_config_free(struct runner_config *config, const int flags)
 {
         if (NULL == config) {
-                pr_info(ERROR, "invalid config location: %p\n", config);
+                pr_info(WARNING, "invalid config location: %p\n", config);
                 return;
         }
 
@@ -143,6 +143,7 @@ exception:
         }
         global_config->setting = NULL;
         runner_config_free(global_config, RUNNER_FREE_ALL);
+        global_config = NULL;
         return ret;
 }
 

--- a/runner/runner.c
+++ b/runner/runner.c
@@ -19,7 +19,7 @@
  * @file runner.c
  * @brief Definition of `runner.h` declaration contents.
  * @author BlaCkinkGJ (ss5kijun@gmail.com)
- * @version 0.1
+ * @version 0.1.1
  * @date 2020-08-04
  */
 


### PR DESCRIPTION
# Fix runner free sequence

1. Added ignorance sequence when the `global_config` has a `NULL` value.

# Refactor tr-driver

1. Added the `tr_has_weight_scheduler` to find the weight supported scheduler.
2. Fixed to ignore the weight value when the scheduler doesn't support the weight.

# Refactor docker-driver

1. Added the `docker_has_weight_scheduler` to find the weight supported  scheduler.
2. Fixed to ignore the weight value when the scheduler doesn't support the weight.