### PR TITLE
[Runner] Change the trace-replay binary file finding sequence

### DIFF
--- a/runner/driver/docker-driver/docker-info.c
+++ b/runner/driver/docker-driver/docker-info.c
@@ -288,8 +288,7 @@ struct docker_info *docker_info_init(struct json_object *setting, int index)
         if (-1 == lstat(info->trace_replay_path, &lstat_info)) {
                 char *buffer = (char *)malloc(sizeof(info->trace_replay_path));
                 assert(NULL != buffer);
-                strncpy(buffer, info->trace_replay_path,
-                        sizeof(info->trace_replay_path));
+                sprintf(buffer, "%s", info->trace_replay_path);
                 sprintf(info->trace_replay_path, "/usr/bin/%s", buffer);
                 pr_info(WARNING, "redirect: %s => %s\n", buffer,
                         info->trace_replay_path);

--- a/runner/driver/docker-driver/docker-info.c
+++ b/runner/driver/docker-driver/docker-info.c
@@ -247,6 +247,7 @@ exception:
 struct docker_info *docker_info_init(struct json_object *setting, int index)
 {
         struct docker_info *info;
+        struct stat lstat_info;
         int ret = 0;
 
         info = (struct docker_info *)malloc(sizeof(struct docker_info));
@@ -281,6 +282,23 @@ struct docker_info *docker_info_init(struct json_object *setting, int index)
                                          DOCKER_ERROR_PRINT);
         if (0 != ret) {
                 pr_info(ERROR, "error detected (errno: %d)\n", ret);
+                goto exception;
+        }
+
+        if (-1 == lstat(info->trace_replay_path, &lstat_info)) {
+                char *buffer = (char *)malloc(sizeof(info->trace_replay_path));
+                assert(NULL != buffer);
+                strncpy(buffer, info->trace_replay_path,
+                        sizeof(info->trace_replay_path));
+                sprintf(info->trace_replay_path, "/usr/bin/%s", buffer);
+                pr_info(WARNING, "redirect: %s => %s\n", buffer,
+                        info->trace_replay_path);
+                free(buffer);
+        }
+
+        if (-1 == lstat(info->trace_replay_path, &lstat_info)) {
+                pr_info(ERROR, "Cannot find the trace_replay_path: %s\n",
+                        info->trace_replay_path);
                 goto exception;
         }
 

--- a/runner/driver/tr-driver/tr-driver.c
+++ b/runner/driver/tr-driver/tr-driver.c
@@ -326,7 +326,6 @@ static int tr_set_cgroup_state(struct tr_info *current)
 static int tr_do_exec(struct tr_info *current)
 {
         struct tr_info info;
-        struct stat lstat_info;
         char filename[PATH_MAX];
 
         char q_depth_str[PAGE_SIZE / 4];
@@ -364,11 +363,6 @@ static int tr_do_exec(struct tr_info *current)
 #ifdef DEBUG
         tr_print_info(&info);
 #endif
-        if (-1 == lstat(info.trace_replay_path, &lstat_info)) {
-                pr_info(ERROR, "trace replay doesn't exist: \"%s\"\n",
-                        info.trace_replay_path);
-                return -EACCES;
-        }
         return execlp(info.trace_replay_path, info.trace_replay_path,
                       q_depth_str, nr_thread_str, filename, time_str,
                       trace_repeat_str, device_path, info.trace_data_path,


### PR DESCRIPTION
1. Removed the trace-replay binary file finding sequence in `tr-driver.c`
2. Added to redirect the directory when the `docker-driver` doesn't find the valid directory.