### PR TITLE
[Runner] Fix the tr_valid_scheduler_test function.

### DIFF
--- a/runner/driver/docker-driver/docker-driver.c
+++ b/runner/driver/docker-driver/docker-driver.c
@@ -19,7 +19,7 @@
  * @file docker-driver.c
  * @brief Implementation of run the `trace-replay` benchmark with Docker.
  * @author SuhoSon (ngeol564@gmail.com)
- * @version 0.1.1
+ * @version 0.1.2
  * @date 2020-08-19
  */
 
@@ -137,17 +137,19 @@ static void __docker_free(void)
  *
  * @param[in] scheduler Inputted scheduler string.
  *
- * @return 0 for mean support the scheduler, -EINVAL for mean don't support the scheduler.
+ * @return 0 and positive integer for mean support the scheduler, -EINVAL for mean don't support the scheduler.
  */
 int docker_valid_scheduler_test(const char *scheduler)
 {
-        const char *index = docker_valid_scheduler[0];
-        while (index != NULL) {
-                if (strcmp(scheduler, index) == 0) {
-                        return 0;
+        int index = 0;
+        const char *current = NULL;
+
+        while (NULL != (current = docker_valid_scheduler[index++])) {
+                if (0 == strcmp(scheduler, current)) {
+                        return index - 1;
                 }
-                index++;
         }
+
         return -EINVAL;
 }
 
@@ -341,7 +343,7 @@ static int docker_set_cgroup_state(struct docker_info *current)
         int ret = 0;
 
         ret = docker_valid_scheduler_test(current->scheduler);
-        if (ret) {
+        if (0 > ret) {
                 pr_info(ERROR, "Cannot support the scheduler: \"%s\"\n",
                         current->scheduler);
                 return ret;

--- a/runner/driver/docker-driver/docker-info.c
+++ b/runner/driver/docker-driver/docker-info.c
@@ -19,7 +19,7 @@
  * @file docker-info.c
  * @brief Initialize the info structure.
  * @author SuhoSon (ngeol564@gmail.com)
- * @version 0.1.1
+ * @version 0.1.2
  * @date 2020-08-19
  */
 
@@ -177,7 +177,7 @@ static int __docker_info_init(struct json_object *setting, int index,
         docker_info_str_value_set(tmp, "device", info->device,
                                   sizeof(info->device), DOCKER_PRINT_NONE);
         ret = docker_valid_scheduler_test(info->scheduler);
-        if (0 != ret) {
+        if (0 > ret) {
                 pr_info(ERROR, "Unsupported scheduler (name: %s)\n",
                         info->scheduler);
                 goto exception;
@@ -302,7 +302,7 @@ struct docker_info *docker_info_init(struct json_object *setting, int index)
         }
 
         ret = docker_valid_scheduler_test(info->scheduler);
-        if (0 != ret) {
+        if (0 > ret) {
                 pr_info(ERROR, "Unsupported scheduler (name: %s)\n",
                         info->scheduler);
                 goto exception;

--- a/runner/driver/tr-driver/tr-driver.c
+++ b/runner/driver/tr-driver/tr-driver.c
@@ -19,7 +19,7 @@
  * @file tr-driver.c
  * @brief Implementation of run the `trace-replay` benchmark.
  * @author BlaCkinkGJ (ss5kijun@gmail.com)
- * @version 0.1.1
+ * @version 0.1.2
  * @date 2020-08-05
  */
 
@@ -138,16 +138,16 @@ static void __tr_free(void)
  *
  * @param[in] scheduler Inputted scheduler string.
  *
- * @return 0 for mean support the scheduler, -EINVAL for mean don't support the scheduler.
+ * @return 0 and positive integer for mean support the scheduler, -EINVAL for mean don't support the scheduler.
  */
 int tr_valid_scheduler_test(const char *scheduler)
 {
-        const char *index = tr_valid_scheduler[0];
-        while (index != NULL) {
-                if (strcmp(scheduler, index) == 0) {
-                        return 0;
+        int index = 0;
+        const char *current = NULL;
+        while (NULL != (current = tr_valid_scheduler[index++])) {
+                if (0 == strcmp(scheduler, current)) {
+                        return index - 1;
                 }
-                index++;
         }
         return -EINVAL;
 }
@@ -277,7 +277,7 @@ static int tr_set_cgroup_state(struct tr_info *current)
         }
 
         ret = tr_valid_scheduler_test(current->scheduler);
-        if (ret) {
+        if (0 > ret) {
                 pr_info(ERROR, " Cannot support the scheduler: \"%s\"\n",
                         current->scheduler);
                 return ret;

--- a/runner/driver/tr-driver/tr-info.c
+++ b/runner/driver/tr-driver/tr-info.c
@@ -19,7 +19,7 @@
  * @file tr-info.c
  * @brief Initialize the info structure.
  * @author BlaCkinkGJ (ss5kijun@gmail.com)
- * @version 0.1.1
+ * @version 0.1.2
  * @date 2020-08-10
  */
 
@@ -166,7 +166,7 @@ static int __tr_info_init(struct json_object *setting, int index,
         tr_info_str_value_set(tmp, "device", info->device, sizeof(info->device),
                               TR_PRINT_NONE);
         ret = tr_valid_scheduler_test(info->scheduler);
-        if (0 != ret) {
+        if (0 > ret) {
                 pr_info(ERROR, "Unsupported scheduler (name: %s)\n",
                         info->scheduler);
                 return ret;
@@ -268,7 +268,7 @@ struct tr_info *tr_info_init(struct json_object *setting, int index)
         }
 
         ret = tr_valid_scheduler_test(info->scheduler);
-        if (0 != ret) {
+        if (0 > ret) {
                 pr_info(ERROR, "Unsupported scheduler (name: %s)\n",
                         info->scheduler);
                 goto exception;


### PR DESCRIPTION
I found that `tr_valid_scheduler_test` doesn't work correctly.
It iterates character array one by one.
In other words, it iterates like "sample", "ample", "mple".

Note that previous version returns 0 or -EINVAL but current version
returns 0, positive number or -EINVAL.

- 0, positive number: It is valid scheduler and means scheduler index.
- -EINVAL: Invalid scheduler.