### PR TITLE
feat(runner): support redhat based linux distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
       - pip3 install scons
       - pip3 install clang-format 
       - pip3 install lizard
+      - pip3 install distro
       - lizard runner && lizard include
       script:
       - scons

--- a/README.md
+++ b/README.md
@@ -86,18 +86,34 @@ You can get more information from this [link](https://github.com/I-O-Benchmark-O
 You download the source code and install necessary programs
 and libraries following.
 
+### Debian
+
 ```bash
 sudo pip3 install scons scons-compiledb
 sudo pip3 install clang-format
 sudo apt install cppcheck libaio-dev libjson-c-dev libjemalloc-dev
 ```
 
+### Redhat
+
+```bash
+sudo yum install cppcheck libaio-devel json-c-devel jemalloc-devel
+```
+
 If you want to build by `clang` compiler then you must change the
 `SConstruct` file's `CC` section' `gcc` to `clang` and follow like below.
+
+### Debian
 
 ```bash
 sudo apt install llvm-6.0 clang-6.0 libclang-6.0-dev
 sudo ln -s /usr/bin/clang-6.0 /usr/bin/clang
+```
+
+### Redhat
+
+```bash
+sudo yum install llvm6.0 clang7.0-devel clang7.0-libs
 ```
 
 Based on the following commands you do the build and unit testing.
@@ -124,6 +140,14 @@ If you want to install the debug mode then just change the
 sudo scons install
 sudo ldconfig
 ```
+
+> Under the redhat distribution, you must care about two things.
+>
+> First, you have to check `/etc/ld.so.conf` file has the line `/usr/local/lib`.
+> If not you add that line.
+>
+> Second, if you encounter an error that related to the `jemalloc`
+> you must build the `jemalloc` library based on this [link](https://stackoverflow.com/questions/50839284/how-to-dlopen-jemalloc-dynamic-library).
 
 Additionally, you can get information about
 how to make the driver program of the runner from [this link](https://github.com/I-O-Benchmark-On-Container/ContainerTracer/wiki/4.-How-to-add-the-driver-to-Runner)

--- a/SConstruct
+++ b/SConstruct
@@ -2,11 +2,13 @@ import scons_compiledb
 import platform
 import subprocess
 import os
+import distro
 
 SConscript('setting/SConscript')
 
 Import('env')
 scons_compiledb.enable(env)
+
 
 if env["BUILD_UNIT_TEST"] == True:
 	if os.getuid() != 0:
@@ -15,6 +17,10 @@ if env["BUILD_UNIT_TEST"] == True:
 
 env.Append(CFLAGS=["-O2"])
 env['CC']=["gcc"]
+
+is_redhat = (len(set(['fedora', 'redhat', 'centos']) & set([s.lower() for s in distro.linux_distribution()])) > 0)
+if is_redhat:
+        env.Append(CFLAGS=["-DREDHAT_LINUX"])
 
 if env["DEBUG"] == True:
 	env.Append(CFLAGS=["-g", "-pg"])

--- a/documentation/README-KOR.md
+++ b/documentation/README-KOR.md
@@ -77,18 +77,34 @@ sudo python web/run.py
 
 소스 코드를 다운 받은 후에 빌드에 필요한 프로그램을 설치하도록 합니다.
 
+### Debian
+
 ```bash
 sudo pip3 install scons scons-compiledb
 sudo pip3 install clang-format
 sudo apt install cppcheck libaio-dev libjson-c-dev libjemalloc-dev
 ```
 
+### Redhat
+
+```bash
+sudo yum install cppcheck libaio-devel json-c-devel jemalloc-devel
+```
+
 추가로 본 프로젝트는 clang을 기반으로 하기 때문에 clang도 설치해주셔야 합니다.
 만약에 \[1\]을 수행한 후에 `clang --version` 했을 때, 문제가 발생하지 않으면 \[2\] 과정은 무시해도 됩니다.
+
+### Debian
 
 ```bash
 sudo apt install llvm-6.0 clang-6.0 libclang-6.0-dev # [1]
 sudo ln -s /usr/bin/clang-6.0 /usr/bin/clang # [2]
+```
+
+### Redhat
+
+```bash
+sudo yum install llvm6.0 clang7.0-devel clang7.0-libs
 ```
 
 그리고 아래의 명령을 통해서 빌드 및 테스트를 수행합니다. 결과물은 `./build/debug`에 저장됩니다.
@@ -112,6 +128,13 @@ scons
 sudo scons install
 sudo ldconfig
 ```
+> 레드헷 환경에서는 반드시 아래 2가지를 유념하셔야 합니다.
+>
+> 첫번째, `/etc/ld.so.conf` 파일에 `/usr/local/lib` 줄이 있는지 확인해야 합니다.
+> 만약 해당 줄이 없는 경우에는 해당 라인을 추가해줘야 합니다.
+>
+> 두번째, 만약 `jemalloc`과 관계된 에러가 확인되면 `jemalloc` 라이브러리를
+> [링크](https://stackoverflow.com/questions/50839284/how-to-dlopen-jemalloc-dynamic-library)에 따라서 설치해야 합니다.
 
 추가적으로 드라이버 제작 방법 관련해서는 [링크](https://github.com/I-O-Benchmark-On-Container/ContainerTracer/wiki/4.-How-to-add-the-driver-to-Runner)를
 확인해주시길 바랍니다.

--- a/include/driver/tr-driver.h
+++ b/include/driver/tr-driver.h
@@ -54,6 +54,20 @@
 #define tr_json_field_traverse(ptr, begin, end)                                \
         for (ptr = begin; ptr != end; ptr++)
 
+#ifdef REDHAT_LINUX
+#pragma message "Compile redhat version"
+#define TR_CGROUP_PREFIX "/sys/fs/cgroup/"
+#define TR_CGROUP_WEIGHT_PREFIX "io"
+#define TR_CGROUP_SET_PID "cgroup.procs"
+#endif
+
+#ifndef REDHAT_LINUX
+#pragma message "Compile not redhat version"
+#define TR_CGROUP_PREFIX "/sys/fs/cgroup/blkio/"
+#define TR_CGROUP_WEIGHT_PREFIX "blkio"
+#define TR_CGROUP_SET_PID "tasks"
+#endif
+
 #ifdef DEBUG
 #define tr_print_info(info)                                                    \
         pr_info(INFO,                                                          \

--- a/include/trace_replay.h
+++ b/include/trace_replay.h
@@ -241,6 +241,7 @@ struct total_results {
         struct result results;
 };
 
+#ifndef _ASM_GENERIC_INT_LL64_H // This for the Redhat Linux
 #ifndef __s8
 typedef char __s8;
 #endif
@@ -258,7 +259,8 @@ typedef unsigned int __u32;
 #if TEST_OS == LINUX
 typedef unsigned long long __u64;
 #endif
-
+#define _ASM_GENERIC_INT_LL64_H // This for the Redhat Linux
+#endif
 long long get_total_bytes(int nr_trace, int nr_thread);
 void synthetic_mix(struct trace_info_t *trace);
 

--- a/runner/driver/tr-driver/tr-driver.c
+++ b/runner/driver/tr-driver/tr-driver.c
@@ -267,7 +267,7 @@ static int tr_set_cgroup_state(struct tr_info *current)
         char cmd[PATH_MAX];
 
         /* Generate cgroup seqeunce. */
-        snprintf(cmd, PATH_MAX, "mkdir /sys/fs/cgroup/blkio/%s%d",
+        snprintf(cmd, PATH_MAX, "mkdir " TR_CGROUP_PREFIX "%s%d",
                  current->prefix_cgroup_name, current->pid);
         pr_info(INFO, "Do command: \"%s\"\n", cmd);
         ret = system(cmd);
@@ -290,7 +290,8 @@ static int tr_set_cgroup_state(struct tr_info *current)
                         return -EINVAL;
                 }
                 snprintf(cmd, PATH_MAX,
-                         "echo %d > /sys/fs/cgroup/blkio/%s%d/blkio.%s.weight",
+                         "echo %d > " TR_CGROUP_PREFIX
+                         "%s%d/" TR_CGROUP_WEIGHT_PREFIX ".%s.weight",
                          current->weight, current->prefix_cgroup_name,
                          current->pid, current->scheduler);
                 pr_info(INFO, "Do command: \"%s\"\n", cmd);
@@ -301,7 +302,8 @@ static int tr_set_cgroup_state(struct tr_info *current)
                 }
         }
 
-        snprintf(cmd, PATH_MAX, "echo %d > /sys/fs/cgroup/blkio/%s%d/tasks",
+        snprintf(cmd, PATH_MAX,
+                 "echo %d > " TR_CGROUP_PREFIX "%s%d/" TR_CGROUP_SET_PID,
                  current->pid, current->prefix_cgroup_name, current->pid);
         pr_info(INFO, "Do command: \"%s\"\n", cmd);
         ret = system(cmd);
@@ -381,7 +383,7 @@ int tr_runner(void)
         char cmd[PATH_MAX];
         pid_t pid;
 
-        snprintf(cmd, PATH_MAX, "rmdir /sys/fs/cgroup/blkio/%s*",
+        snprintf(cmd, PATH_MAX, "rmdir " TR_CGROUP_PREFIX "%s*",
                  current->prefix_cgroup_name);
         pr_info(INFO, "Do command: \"%s\"\n", cmd);
         ret = system(cmd); /* You can ignore this return value. */


### PR DESCRIPTION
feat(runner): support redhat based linux distribution

I added the support of RedHat based Linux distribution.

More specific changes are following.

- `.travis.ci`: added `distro` package for detect distribution.
- `README.md`: added support information of the RedHat linux.
- `README-KOR.md`: same as `README.md`
- `SConstruct`: added RedHat Linux recognition feature.
- `include/driver/tr-driver.h`: defined the cgroup prefix macros.
- `include/trace_replay.h`: removed the redundancy define in type.
- `runner/driver/tr-driver/tr-driver.c`: changed to use the cgroup prefix macros
  which are defined in the `include/driver/tr-driver.h`