### PR TITLE
Change the git commit rules.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,7 @@ repos:
     hooks:
     - id: flake8
       types: [python]
+-   repo: https://github.com/jorisroovers/gitlint
+    rev: master
+    hooks:
+    -   id: gitlint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Common Rules
 
 You must comment the all source code except `trace-replay` based on `Doxygen` style.
+And commit message must follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) style.
 
 ## `web` Contributing Rules
 


### PR DESCRIPTION
The git commit rule has been changed from our own rule to the [`conventional commit`](https://www.conventionalcommits.org/en/v1.0.0/) rule.

[gitlint](https://jorisroovers.com/gitlint/) feature has been added in `pre-commit` to follow the `conventional commit`. Therefore, those who will contribute this project, please be sure to execute the following command.

```bash
pre-commit install
```

If you want to check the pre-commit's gitlint state, please execute the command below.

```bash
pre-commit run --hook-stage commit-msg --commit-msg-filename .git/COMMIT_EDITMSG
```