### PR TITLE
[ALL] Add the build feature to select the specific test target device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This execution results are stored in `./build/debug`.
 
 ```bash
 sudo scons -c
-sudo scons test DEBUG=True
+sudo scons test DEBUG=True TARGET_DEVICE=<your device>
 ```
 
 If you want to build the release mode then you do the following.

--- a/SConstruct
+++ b/SConstruct
@@ -15,6 +15,13 @@ if env["BUILD_UNIT_TEST"] == True:
 		print("[ERROR] `test` mode requires the sudo privileges.", file=sys.stderr)
 		sys.exit()
 
+	if env["TARGET_DEVICE"] == "":
+		print("[ERROR] you must specify the TARGET_DEVICE (e.g. nvme0n1)", file=sys.stderr)
+		sys.exit()
+        else:
+		env.Append(CFLAGS=["-DTEST_DISK_PATH={}".format(env["TARGET_DEVICE"])]
+
+
 env.Append(CFLAGS=["-O2"])
 env['CC']=["gcc"]
 
@@ -22,13 +29,12 @@ is_redhat = (len(set(['fedora', 'redhat', 'centos']) & set([s.lower() for s in d
 if is_redhat:
         env.Append(CFLAGS=["-DREDHAT_LINUX"])
 
+
 if env["DEBUG"] == True:
 	env.Append(CFLAGS=["-g", "-pg"])
 	env.Append(CFLAGS=["-DLOG_INFO", "-DDEBUG"])
 	env.Append(LINKFLAGS=["-g", "-pg"])
 	env["PROGRAM_LOCATION"] = "#build/debug"
-else:
-	pass
 
 
 if env["BUILD_UNIT_TEST"]:

--- a/SConstruct
+++ b/SConstruct
@@ -4,46 +4,52 @@ import subprocess
 import os
 import distro
 
-SConscript('setting/SConscript')
+SConscript("setting/SConscript")
 
-Import('env')
+Import("env")
 scons_compiledb.enable(env)
 
-
 if env["BUILD_UNIT_TEST"] == True:
-	if os.getuid() != 0:
-		print("[ERROR] `test` mode requires the sudo privileges.", file=sys.stderr)
-		sys.exit()
+    if os.getuid() != 0:
+        print("[ERROR] `test` mode requires the sudo privileges.", file=sys.stderr)
+        sys.exit()
 
-	if env["TARGET_DEVICE"] == "":
-		print("[ERROR] you must specify the TARGET_DEVICE (e.g. nvme0n1)", file=sys.stderr)
-		sys.exit()
-        else:
-		env.Append(CFLAGS=["-DTEST_DISK_PATH={}".format(env["TARGET_DEVICE"])]
-
+    if env["TARGET_DEVICE"] == "":
+        print(
+            "[ERROR] you must specify the TARGET_DEVICE (e.g. nvme0n1)", file=sys.stderr
+        )
+        sys.exit()
+    else:
+        env.Append(CFLAGS=["-DTEST_DISK_PATH='\"{}\"'".format(env["TARGET_DEVICE"])])
 
 env.Append(CFLAGS=["-O2"])
-env['CC']=["gcc"]
+env["CC"] = ["gcc"]
 
-is_redhat = (len(set(['fedora', 'redhat', 'centos']) & set([s.lower() for s in distro.linux_distribution()])) > 0)
+is_redhat = (
+    len(
+        set(["fedora", "redhat", "centos"])
+        & set([s.lower() for s in distro.linux_distribution()])
+    )
+    > 0
+)
 if is_redhat:
-        env.Append(CFLAGS=["-DREDHAT_LINUX"])
+    env.Append(CFLAGS=["-DREDHAT_LINUX"])
 
 
 if env["DEBUG"] == True:
-	env.Append(CFLAGS=["-g", "-pg"])
-	env.Append(CFLAGS=["-DLOG_INFO", "-DDEBUG"])
-	env.Append(LINKFLAGS=["-g", "-pg"])
-	env["PROGRAM_LOCATION"] = "#build/debug"
+    env.Append(CFLAGS=["-g", "-pg"])
+    env.Append(CFLAGS=["-DLOG_INFO", "-DDEBUG"])
+    env.Append(LINKFLAGS=["-g", "-pg"])
+    env["PROGRAM_LOCATION"] = "#build/debug"
 
 
 if env["BUILD_UNIT_TEST"]:
-	SConscript("unity/SConscript")
+    SConscript("unity/SConscript")
 SConscript("include/SConscript")
 
 sub_project = {
-	'trace-replay/SConscript': env['TRACE_REPLAY'],
-	'runner/SConscript': env['RUNNER'],
+    "trace-replay/SConscript": env["TRACE_REPLAY"],
+    "runner/SConscript": env["RUNNER"],
 }
 
 # Program existence check.
@@ -56,28 +62,26 @@ try:
         current_check_program = program
         subprocess.call([cmd, program], stdout=subprocess.DEVNULL)
 except:
-    print(current_check_program+"isn't properlly installed.", file=sys.stderr)
+    print(current_check_program + "isn't properlly installed.", file=sys.stderr)
 
 # Make a directory for log
 os.makedirs(str(Dir(env["LOG_LOCATION"])), exist_ok=True)
 
 # Execute the clang-format
 clang_format_ouput_file = open(
-    str(Dir(env["LOG_LOCATION"]))
-    + os.sep
-    + dependency[0]
-    + ".log",
+    str(Dir(env["LOG_LOCATION"])) + os.sep + dependency[0] + ".log",
     "w",
 )
 clang_format_error_file = open(
-    str(Dir(env["LOG_LOCATION"]))
-    + os.sep
-    + dependency[0]
-    + ".error",
+    str(Dir(env["LOG_LOCATION"])) + os.sep + dependency[0] + ".error",
     "w",
 )
 proc = subprocess.Popen(
-    "find ."+os.sep+" -iname '*.h' -o -iname '*.c' | xargs "+ str(dependency[0]) +' -i',
+    "find ."
+    + os.sep
+    + " -iname '*.h' -o -iname '*.c' | xargs "
+    + str(dependency[0])
+    + " -i",
     shell=True,
     stdout=clang_format_ouput_file,
     stderr=clang_format_error_file,
@@ -87,40 +91,38 @@ clang_format_ouput_file.close()
 clang_format_error_file.close()
 
 for sub_project_root, do_make in sub_project.items():
-	if do_make:
-		SConscript(sub_project_root)
+    if do_make:
+        SConscript(sub_project_root)
 
-if env.GetOption('help'):
-	env.PrintHelp()
+if env.GetOption("help"):
+    env.PrintHelp()
 
 env.CompileDb()
 
 # Execute the cppcheck
 cppcheck_ouput_file = open(
-    str(Dir(env["LOG_LOCATION"]))
-    + os.sep
-    + dependency[1]
-    + ".log",
+    str(Dir(env["LOG_LOCATION"])) + os.sep + dependency[1] + ".log",
     "w",
 )
 cppcheck_error_file = open(
-    str(Dir(env["LOG_LOCATION"]))
-    + os.sep
-    + dependency[1]
-    + ".error",
+    str(Dir(env["LOG_LOCATION"])) + os.sep + dependency[1] + ".error",
     "w",
 )
 subprocess.call(
-    [dependency[1], "--check-config","--enable=all", "--project=./compile_commands.json"],
+    [
+        dependency[1],
+        "--check-config",
+        "--enable=all",
+        "--project=./compile_commands.json",
+    ],
     stdout=cppcheck_ouput_file,
     stderr=cppcheck_error_file,
 )
 cppcheck_ouput_file.close()
 cppcheck_error_file.close()
 
-if env.GetOption('clean'):
-	print("Delete All Object file manually")
-	os.system("find ./ -name \"*.o\" -print0 | xargs -0 rm -f ")
-	os.system("find ./ -name \"*.os\" -print0 | xargs -0 rm -f ")
-	os.system("rm -rf ./build")
-
+if env.GetOption("clean"):
+    print("Delete All Object file manually")
+    os.system('find ./ -name "*.o" -print0 | xargs -0 rm -f ')
+    os.system('find ./ -name "*.os" -print0 | xargs -0 rm -f ')
+    os.system("rm -rf ./build")

--- a/documentation/README-KOR.md
+++ b/documentation/README-KOR.md
@@ -111,7 +111,7 @@ sudo yum install llvm6.0 clang7.0-devel clang7.0-libs
 
 ```bash
 sudo scons -c
-sudo scons test DEBUG=True
+sudo scons test DEBUG=True TARGET_DEVICE=<당신의 장치>
 ```
 
 배포판을 만드는 경우에는 아래와 같은 방법으로 진행해주시길 바랍니다. 결과물은 `./build/release`에 저장됩니다.

--- a/include/SConscript
+++ b/include/SConscript
@@ -3,4 +3,3 @@ import os
 Import("env")
 
 CURRENT_PROJECT = "include"
-

--- a/runner/test/docker-driver-test.c
+++ b/runner/test/docker-driver-test.c
@@ -44,8 +44,6 @@
 #else
 #define TRACE_REPLAY_PATH "./build/debug/trace-replay"
 #endif
-#define TEST_DISK_PATH                                                         \
-        "sdb" /**< Target device name. Do not contain the `/dev/` */
 #define SCHEDULER "none" /**< "none, bfq" in SCSI; "none, kyber, bfq" in NVMe */
 
 #define TIME (5) /**< seconds */

--- a/runner/test/tr-driver-test.c
+++ b/runner/test/tr-driver-test.c
@@ -44,8 +44,6 @@
 #else
 #define TRACE_REPLAY_PATH "./build/debug/trace-replay"
 #endif
-#define TEST_DISK_PATH                                                         \
-        "sdb" /**< Target device name. Do not contain the `/dev/` */
 #define SCHEDULER "none" /**< "none, bfq" in SCSI; "none, kyber, bfq" in NVMe */
 
 #define TIME (5) /**< seconds */

--- a/setting/SConscript
+++ b/setting/SConscript
@@ -11,10 +11,16 @@ variables.AddVariables(
     BoolVariable("TRACE_REPLAY", "Build the trace-replay", default=True),
     BoolVariable("WEB", "Build the web", default=True),
     BoolVariable("DEBUG", "Enable the debugging mode", default=False),
-    PathVariable("TARGET_DEVICE", "Test target device (NOTICE: You must specify without `/dev/`)", default=""),
+    (
+        "TARGET_DEVICE",
+        "Test target device (NOTICE: You must specify without `/dev/`)",
+        "",
+    ),
 )
 
-env = Environment(variables=variables,)
+env = Environment(
+    variables=variables,
+)
 
 env["PROGRAM_LOCATION"] = "#build/release"
 env["TEST_LOCATION"] = "#build/test"

--- a/setting/SConscript
+++ b/setting/SConscript
@@ -11,6 +11,7 @@ variables.AddVariables(
     BoolVariable("TRACE_REPLAY", "Build the trace-replay", default=True),
     BoolVariable("WEB", "Build the web", default=True),
     BoolVariable("DEBUG", "Enable the debugging mode", default=False),
+    PathVariable("TARGET_DEVICE", "Test target device (NOTICE: You must specify without `/dev/`)", default=""),
 )
 
 env = Environment(variables=variables,)

--- a/trace-replay/SConscript
+++ b/trace-replay/SConscript
@@ -24,10 +24,10 @@ share = shared_env.SharedLibrary(
     target=env["PROGRAM_LOCATION"] + "/" + CURRENT_PROJECT + ".so", source=Glob("*.c")
 )
 
-current_env.Install('/usr/bin', program)
-current_env.Alias('install', '/usr/bin')
+current_env.Install("/usr/bin", program)
+current_env.Alias("install", "/usr/bin")
 
 if current_env["BUILD_UNIT_TEST"] == True:
-	tester = SConscript("test/SConscript")
-	test_alias = Alias("test", [tester, share, program], tester[0].path)
-	AlwaysBuild(test_alias)
+    tester = SConscript("test/SConscript")
+    test_alias = Alias("test", [tester, share, program], tester[0].path)
+    AlwaysBuild(test_alias)

--- a/trace-replay/test/SConscript
+++ b/trace-replay/test/SConscript
@@ -35,4 +35,4 @@ tester = current_env.Program(
     source=Glob("*.o") + Glob(env["UNITY_LOCATION"] + "/*.o") + except_main,
 )
 
-Return ('tester')
+Return("tester")


### PR DESCRIPTION
I added the build feature to select the specific test target device.

Previous the test device value was hard coded in the source codes(e.g. `/runner/test/tr-driver-test.c`).
For this reason, this occurs the high dependency on the device owned by someone who made the test code.

So, I enhanced the build script with the `TARGET_DEVICE` variable. You must type like below to test the build.

- **(NOTICE 1)** The `nvme0n1` is my device's disk name you can change.
- **(NOTICE 2)** You must be aware of the prefix `/dev/` is automatically attached.

```bash
sudo scons test DEBUG=True TARGET_DEVICE=nvme0n1
```

### BELOW FOR DEVELOPER WHO WILL MAKE THE TEST PROGRAM

> If someone who will make the test program related to the I/O benchmark is aware of that test source code MUST use the `TEST_DISK_PATH` to specify the I/O devices. You can refer the example in the `/runner/test/tr-driver-test.c`.